### PR TITLE
alpine-3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/raspberry-pi-alpine:3.9
+FROM balenalib/raspberry-pi-alpine:3.10
 
 LABEL org.opencontainers.image.maintainer="vmnet8 <vmnet8@ole.org>" \
       org.opencontainers.image.title="NGINX" \


### PR DESCRIPTION
In original rpi-dockerfile, the base is FROM balenalib/raspberry-pi-alpine:3.9, in which the alpine is 3.9 .
Compare to orginal Dockerfile, the base is FROM nginx:1.16-alpine, in which the alpine is 3.10.
To keep the rpi-dockerfile and Dockerfile consist with each other, modify the rpi-nginx base image to alpine 3.10 .